### PR TITLE
Fix: Shapes sign-in redirects to auth page instead of app

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -10,6 +10,7 @@ interface AuthContextType {
   signIn: (email: string, password: string) => Promise<{ error: any }>;
   signUp: (email: string, password: string) => Promise<{ error: any }>;
   signOut: () => Promise<void>;
+  refreshShapesAuthStatus: () => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -98,6 +99,29 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  const refreshShapesAuthStatus = () => {
+    setLoading(true);
+    const shapesAuthToken = localStorage.getItem('shapes_auth_token');
+    if (shapesAuthToken) {
+      const mockUser = {
+        id: 'shapes-user',
+        email: 'shapes-user@shapes.local',
+        aud: 'authenticated',
+        created_at: new Date().toISOString(),
+        app_metadata: {},
+        user_metadata: {
+          provider: 'shapes',
+          shapes_auth_token: shapesAuthToken
+        }
+      } as User;
+      setUser(mockUser);
+    } else {
+      setUser(null);
+    }
+    setSession(null); // Shapes auth is not Supabase session based
+    setLoading(false);
+  };
+
   const value = {
     user,
     session,
@@ -105,6 +129,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     signIn,
     signUp,
     signOut,
+    refreshShapesAuthStatus,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/hooks/useShapesAuth.ts
+++ b/src/hooks/useShapesAuth.ts
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { useToast } from '@/hooks/use-toast';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
 
 export function useShapesAuth() {
   const [oneTimeCode, setOneTimeCode] = useState('');
@@ -9,6 +10,7 @@ export function useShapesAuth() {
   const [showCodeInput, setShowCodeInput] = useState(false);
   const { toast } = useToast();
   const navigate = useNavigate();
+  const { refreshShapesAuthStatus } = useAuth();
 
   const redirectToShapesAuth = () => {
     // Use the correct app_id for Euclidian - the Shapes API testing app
@@ -61,6 +63,8 @@ export function useShapesAuth() {
       localStorage.setItem('shapes_auth_token', auth_token);
       localStorage.setItem('shapes_app_id', 'f6263f80-2242-428d-acd4-10e1feec44ee');
       
+      refreshShapesAuthStatus();
+
       toast({
         title: "Success!",
         description: "Successfully authenticated with Shapes. You can now chat with authenticated access.",


### PR DESCRIPTION
Previously, after a successful Shapes sign-in (one-time code exchange), the application would sometimes redirect back to the /auth page instead of the main application page. This was likely due to a race condition where the ProtectedRoute component would check authentication status before the AuthContext had updated its user state based on the Shapes localStorage token.

This commit introduces the following changes:
1. Added `refreshShapesAuthStatus` to `AuthContext.tsx`: This new function allows explicitly triggering a refresh of the authentication state from localStorage, specifically for Shapes auth. It sets the loading state appropriately during this process.
2. Called `refreshShapesAuthStatus` in `useShapesAuth.ts`: After the Shapes one-time code is successfully exchanged for a token and the token is stored in localStorage, `refreshShapesAuthStatus` is called immediately. This ensures the AuthContext updates its user state before the navigation to the main application page occurs.
3. Verified `ProtectedRoute.tsx`: Ensured that the existing loading state check in ProtectedRoute correctly handles the loading state managed by `refreshShapesAuthStatus`, preventing premature redirects.

With these changes, the AuthContext is updated synchronously with the Shapes authentication status before navigation, resolving the redirect issue.