### PR TITLE
Fix: Shapes API uses user ID instead of name in greetings

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -38,17 +38,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       // If no Supabase session, check for Shapes auth
       if (!session) {
         const shapesAuthToken = localStorage.getItem('shapes_auth_token');
+        const shapesUserId = localStorage.getItem('shapes_user_id');
         if (shapesAuthToken) {
           // Create a mock user object for Shapes authentication
           const mockUser = {
-            id: 'shapes-user',
+            id: shapesUserId || 'shapes-user-fallback',
             email: 'shapes-user@shapes.local',
             aud: 'authenticated',
             created_at: new Date().toISOString(),
             app_metadata: {},
             user_metadata: {
               provider: 'shapes',
-              shapes_auth_token: shapesAuthToken
+              shapes_auth_token: shapesAuthToken,
+              actual_shapes_user_id: shapesUserId || undefined,
             }
           } as User;
           
@@ -87,6 +89,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // Clear Shapes auth tokens
     localStorage.removeItem('shapes_auth_token');
     localStorage.removeItem('shapes_app_id');
+    localStorage.removeItem('shapes_user_id');
     
     const { error } = await supabase.auth.signOut();
     
@@ -102,16 +105,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const refreshShapesAuthStatus = () => {
     setLoading(true);
     const shapesAuthToken = localStorage.getItem('shapes_auth_token');
+    const shapesUserId = localStorage.getItem('shapes_user_id');
     if (shapesAuthToken) {
       const mockUser = {
-        id: 'shapes-user',
+        id: shapesUserId || 'shapes-user-fallback-refresh',
         email: 'shapes-user@shapes.local',
         aud: 'authenticated',
         created_at: new Date().toISOString(),
         app_metadata: {},
         user_metadata: {
           provider: 'shapes',
-          shapes_auth_token: shapesAuthToken
+          shapes_auth_token: shapesAuthToken,
+          actual_shapes_user_id: shapesUserId || undefined,
         }
       } as User;
       setUser(mockUser);

--- a/src/hooks/useShapesAuth.ts
+++ b/src/hooks/useShapesAuth.ts
@@ -62,7 +62,15 @@ export function useShapesAuth() {
       // Store the auth token and app_id in localStorage
       localStorage.setItem('shapes_auth_token', auth_token);
       localStorage.setItem('shapes_app_id', 'f6263f80-2242-428d-acd4-10e1feec44ee');
-      
+
+      // Check for user and user.id, then store shapes_user_id
+      if (user && user.id) {
+        localStorage.setItem('shapes_user_id', user.id);
+      } else {
+        console.error('User ID not found in Shapes auth response:', user);
+        // Potentially show a toast to the user as well, or handle this more gracefully
+      }
+
       refreshShapesAuthStatus();
 
       toast({


### PR DESCRIPTION
### **User description**
This commit addresses an issue where the Shapes API would address you by your ID (e.g., "user-12345") instead of your actual name. The root cause was that the client-side application was using a generic or incorrect user ID when representing a Shapes-authenticated user.

Changes implemented:

1.  **Store Actual Shapes User ID (`useShapesAuth.ts`):**
    *   When exchanging the one-time code for a Shapes auth token via
        the `shapes-auth-exchange` Supabase function, the actual `user.id`
        returned by the Shapes service is now extracted from the response.
    *   This `user.id` is stored in `localStorage` as `shapes_user_id`.

2.  **Use Shapes User ID in AuthContext (`AuthContext.tsx`):**
    *   When initializing the authentication state or refreshing the Shapes
        auth status, the `AuthContext` now retrieves `shapes_user_id`
        from `localStorage`.
    *   This retrieved ID is used as the primary `id` field for the
        client-side `user` object representing the Shapes-authenticated user.
        Fallbacks are in place in case the ID is missing.
    *   The `shapes_user_id` is now also cleared from `localStorage` during
        the `signOut` process.

3.  **Verification of X-User-Id Header:**
    *   Confirmed that any code sending an `X-User-Id` header to the
        Shapes API should source this ID from the `auth.user.id` field.
        With the above changes, this field now holds the correct
        Shapes User ID.

This ensures that the application provides the correct user identifier to the Shapes API, enabling the API to look up your profile (including your name) on its backend and personalize responses accordingly. The resolution of the name itself depends on your profile being correctly populated on the Shapes platform.


___

### **PR Type**
Bug fix


___

### **Description**
• Fix Shapes API user identification by storing actual user ID
• Replace generic fallback ID with real Shapes user ID
• Clear stored user ID during sign out process
• Add error handling for missing user ID in auth response


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useShapesAuth.ts</strong><dd><code>Store actual Shapes user ID from auth response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/useShapesAuth.ts

• Extract and store actual user ID from Shapes auth response<br> • Add <br>error handling for missing user ID<br> • Store <code>shapes_user_id</code> in <br>localStorage after successful auth


</details>


  </td>
  <td><a href="https://github.com/bgill55/shape-shift-chat/pull/8/files#diff-73dd3a9716eb81ad805af6211b3fe2b7d675e0cc7764b0ac113d0bf85d9751ba">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AuthContext.tsx</strong><dd><code>Use real Shapes user ID in auth context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/contexts/AuthContext.tsx

• Use stored Shapes user ID instead of generic fallback<br> • Add <br><code>shapes_user_id</code> to user metadata for tracking<br> • Clear stored user ID <br>during sign out process<br> • Update both initial auth check and refresh <br>functions


</details>


  </td>
  <td><a href="https://github.com/bgill55/shape-shift-chat/pull/8/files#diff-cf239e897193b2687998acaf21bc04a2e009dcf7253005cdf7fb92da6afc25fb">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>