### PR TITLE
Fix: Correct syntax error and ensure UserMenu visibility

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -13,7 +13,10 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { Separator } from "@/components/ui/separator"; // Added
 import { Checkbox } from "@/components/ui/checkbox";
+import { useAuth } from "@/contexts/AuthContext"; // Added
+import { UserMenu } from "@/components/UserMenu"; // Added
 import { Chatbot } from '@/pages/Index';
 import { Button } from "@/components/ui/button";
 
@@ -35,6 +38,7 @@ export function AppSidebar({
   onOpenApiConfig 
 }: AppSidebarProps) {
   const { open } = useSidebar();
+  const { user } = useAuth(); // Added
 
   const isChatbotSelected = (chatbot: Chatbot) => {
     return selectedChatbots.some(selected => selected.id === chatbot.id);
@@ -159,7 +163,7 @@ export function AppSidebar({
         )}
       </SidebarContent>
 
-      <SidebarFooter className="p-4 border-t border-[#202225]">
+      <SidebarFooter className="p-4 border-t border-[#202225] space-y-3">
         <SidebarMenuButton 
           onClick={onOpenApiConfig}
           className="w-full justify-start text-left px-2 py-2 rounded hover:bg-[#393c43] text-[#96989d]"
@@ -167,6 +171,15 @@ export function AppSidebar({
           <Settings className="w-4 h-4 mr-3" />
           <span>API Configuration</span>
         </SidebarMenuButton>
+
+        {user && (
+          <>
+            <Separator className="bg-[#393c43]" />
+            <div className="flex items-center justify-center w-full">
+              <UserMenu />
+            </div>
+          </>
+        )}
       </SidebarFooter>
     </Sidebar>
   );

--- a/src/pages/ProfileSettings.tsx
+++ b/src/pages/ProfileSettings.tsx
@@ -115,11 +115,3 @@ export function ProfileSettings() {
     </div>
   );
 }
-
-// Export default for lazy loading if ever needed, or keep as named.
-// export default ProfileSettings;
-```
-
-Now, before I mark that file as "created", I need to check if `Label` is available. If not, I'll use the standard HTML `label`. I'll assume `@/components/ui/label` exists as it's common with `shadcn/ui`. If it causes an error later, I'll adjust.
-
-Next, I'll modify `src/App.tsx`. I need to read its content first.


### PR DESCRIPTION
This commit addresses two issues:

1.  **Fix Syntax Error in ProfileSettings.tsx:**
    *   Removed extraneous non-code text that was accidentally inserted
        at the end of `src/pages/ProfileSettings.tsx`, which caused a
        syntax error during build.

2.  **Ensure UserMenu Visibility on Desktop:**
    *   The `UserMenu` component is now rendered in the `SidebarFooter`
        of `src/components/AppSidebar.tsx`.
    *   It is conditionally displayed only when you are authenticated.
    *   A `Separator` has been added for visual distinction from other
        footer items.
    *   This makes the UserMenu, along with links to Profile Settings
        and Sign Out, accessible on desktop layouts.