### PR TITLE
fix: Correct PWA install button handler

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -64,7 +64,7 @@ export function AppSidebar({
   const handleInstallClick = () => {
     const pwaInstallElement = document.getElementById('pwa-install-dialog') as any;
     if (pwaInstallElement) {
-      pwaInstallElement.showDialog();
+      pwaInstallElement.install();
     } else {
       console.error('PWA install component not found. Make sure it is mounted in the DOM.');
     }


### PR DESCRIPTION
The 'Install App' button was calling `showDialog()` on the `pwa-install` custom element. According to the library's documentation, the correct method to trigger the installation is `install()`. This commit changes the event handler to call the correct method.