### PR TITLE
feat: Migrate from shapes.inc to OpenRouter API

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 
     <meta property="og:title" content="Shape Shift" />
     <meta property="og:description" content="A Shift in the way you interact with your Shape" />
-    <meta property="og:type" content="https://shapes.inc/bgill55.art" />
+    <meta property="og:type" content="https://openrouter.ai/bgill55.art" />
 
     <meta name="twitter:card" content="assets/X_large_image.png" />
   </head>

--- a/src/components/AddModelModal.tsx
+++ b/src/components/AddModelModal.tsx
@@ -1,17 +1,16 @@
-
 import { useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
 
-interface AddShapeModalProps {
+interface AddModelModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onAddShape: (url: string) => void;
+  onAddModel: (url: string) => void;
 }
 
-export function AddShapeModal({ isOpen, onClose, onAddShape }: AddShapeModalProps) {
+export function AddModelModal({ isOpen, onClose, onAddModel }: AddModelModalProps) {
   const [url, setUrl] = useState('');
   const [showSuccess, setShowSuccess] = useState(false);
   const { toast } = useToast();
@@ -28,16 +27,16 @@ export function AddShapeModal({ isOpen, onClose, onAddShape }: AddShapeModalProp
       return;
     }
 
-    if (!url.includes('shapes.inc/')) {
+    if (!url.includes('openrouter.ai/')) {
       toast({
         title: "Error", 
-        description: "Please enter a valid Shapes.inc URL",
+        description: "Please enter a valid OpenRouter URL",
         variant: "destructive"
       });
       return;
     }
 
-    onAddShape(url);
+    onAddModel(url);
     setShowSuccess(true);
     
     setTimeout(() => {
@@ -57,24 +56,24 @@ export function AddShapeModal({ isOpen, onClose, onAddShape }: AddShapeModalProp
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent className="bg-[rgb(var(--card))] border-[rgb(var(--border))] text-[rgb(var(--fg))] max-w-md">
         <DialogHeader className="pb-4">
-          <DialogTitle className="text-2xl font-semibold text-card-foreground">Add New Shape</DialogTitle>
+          <DialogTitle className="text-2xl font-semibold text-card-foreground">Add New Model</DialogTitle>
           <DialogDescription className="text-muted-foreground">
-            Enter a Shape's vanity URL to add it to your collection. Example: https://shapes.inc/jarvis-dev
+            Enter a Model's vanity URL to add it to your collection. Example: https://openrouter.ai/google/gemini-flash-1.5
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label htmlFor="shape-url" className="block text-sm font-medium mb-2 text-foreground">
-                Shape URL
+              <label htmlFor="model-url" className="block text-sm font-medium mb-2 text-foreground">
+                Model URL
               </label>
               <Input
-                id="shape-url"
+                id="model-url"
                 type="url"
                 value={url}
                 onChange={(e) => setUrl(e.target.value)}
-                placeholder="https://shapes.inc/shape-name"
+                placeholder="https://openrouter.ai/google/gemini-flash-1.5"
                 className="bg-input border-border text-foreground placeholder-muted-foreground"
                 disabled={showSuccess}
               />
@@ -82,7 +81,7 @@ export function AddShapeModal({ isOpen, onClose, onAddShape }: AddShapeModalProp
 
             {showSuccess && (
               <div className="text-green-500 text-center font-medium">
-                Shape added successfully!
+                Model added successfully!
               </div>
             )}
 
@@ -91,7 +90,7 @@ export function AddShapeModal({ isOpen, onClose, onAddShape }: AddShapeModalProp
                 type="submit"
                 className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
               >
-                Add Shape
+                Add Model
               </Button>
             )}
           </form>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,9 +1,8 @@
-
 import { useState, useEffect } from 'react';
 import { SidebarProvider, useSidebar } from "@/components/ui/sidebar";
 import { AppSidebar } from '@/components/AppSidebar';
 import { ChatArea } from '@/components/ChatArea';
-import { AddShapeModal } from '@/components/AddShapeModal';
+import { AddModelModal } from '@/components/AddModelModal';
 import { ApiKeyModal } from '@/components/ApiKeyModal';
 import { MobileHeader } from '@/components/MobileHeader';
 import { useToast } from '@/hooks/use-toast';
@@ -22,7 +21,7 @@ export interface Chatbot {
 const Index = () => {
   const [chatbots, setChatbots] = useState<Chatbot[]>([]);
   const [selectedChatbots, setSelectedChatbots] = useState<Chatbot[]>([]);
-  const [isAddShapeModalOpen, setIsAddShapeModalOpen] = useState(false);
+  const [isAddModelModalOpen, setIsAddModelModalOpen] = useState(false);
   const [isApiKeyModalOpen, setIsApiKeyModalOpen] = useState(false);
   const [apiKey, setApiKey] = useState<string>('');
   const { toast } = useToast();
@@ -37,7 +36,7 @@ const Index = () => {
   }, [loadSavedChats]);
 
   useEffect(() => {
-    const savedApiKey = localStorage.getItem('shapes-api-key');
+    const savedApiKey = localStorage.getItem('openrouter_api_key');
     if (savedApiKey) {
       setApiKey(savedApiKey);
     }
@@ -66,7 +65,7 @@ const Index = () => {
     
     // Show success toast
     toast({
-      title: "Shape Added Successfully!",
+      title: "Model Added Successfully!",
       description: `${newChatbot.name} now has its own dedicated channel.`,
     });
   };
@@ -79,7 +78,7 @@ const Index = () => {
       } else {
         toast({
           title: "Maximum Reached",
-          description: "You can select up to 3 shapes for a group chat.",
+          description: "You can select up to 3 models for a group chat.",
           variant: "destructive"
         });
       }
@@ -136,14 +135,14 @@ const Index = () => {
     setSelectedChatbots(prev => prev.filter(bot => bot.id !== chatbotId));
 
     toast({
-      title: "Shape Deleted",
+      title: "Model Deleted",
       description: "Chatbot has been successfully removed.",
     });
   };
 
   const saveApiKey = (key: string) => {
     setApiKey(key);
-    localStorage.setItem('shapes-api-key', key);
+    localStorage.setItem('openrouter_api_key', key);
   };
 
   return (
@@ -152,7 +151,7 @@ const Index = () => {
         <div className="min-h-screen flex w-full relative">
           {/* Mobile Header */}
           <MobileHeader 
-            onAddShape={() => setIsAddShapeModalOpen(true)}
+            onAddModel={() => setIsAddModelModalOpen(true)}
             onOpenApiConfig={() => setIsApiKeyModalOpen(true)}
           />
           
@@ -161,7 +160,7 @@ const Index = () => {
             selectedChatbots={selectedChatbots}
             onSelectChatbot={handleChatbotSelection}
             onSelectSingleChatbot={handleSelectSingleChatbot}
-            onAddShape={() => setIsAddShapeModalOpen(true)}
+            onAddModel={() => setIsAddModelModalOpen(true)}
             onOpenApiConfig={() => setIsApiKeyModalOpen(true)}
             savedChats={savedChats}
             onLoadChat={handleLoadChat}
@@ -183,10 +182,10 @@ const Index = () => {
         </div>
       </SidebarProvider>
 
-      <AddShapeModal 
-        isOpen={isAddShapeModalOpen}
-        onClose={() => setIsAddShapeModalOpen(false)}
-        onAddShape={addChatbot}
+      <AddModelModal
+        isOpen={isAddModelModalOpen}
+        onClose={() => setIsAddModelModalOpen(false)}
+        onAddModel={addChatbot}
       />
 
       <ApiKeyModal 


### PR DESCRIPTION
This commit migrates the application from the deprecated shapes.inc API to the OpenRouter API.

Changes include:
- Replaced all instances of `shapes.inc` with `openrouter.ai`.
- Renamed `AddShapeModal` to `AddModelModal` and updated its usage.
- Removed the `useShapesAuth` hook and the `Auth.tsx` page, as they are no longer needed.
- Removed the `get-suggestions` and `shapes-auth-exchange` Supabase functions.
- Updated `eslint.config.js` and `supabase/setup_chats_rls.sql` to remove references to the deleted functions and old terminology.
- Updated the local storage key for the API key to `openrouter_api_key`.